### PR TITLE
Bumped release version to 1.0.1 in order to access latest changes when using CocoaPods

### DIFF
--- a/KNMultiItemSelector.podspec
+++ b/KNMultiItemSelector.podspec
@@ -6,7 +6,7 @@ Pod::Spec.new do |s|
   s.author   = { 'Kent Nguyen' => 'nguyen.dmz@gmail.com' }
   s.platform = :ios
   s.version  = '1.0.1'
-  s.source   = { :git => 'https://github.com/kentnguyen/KNMultiItemSelector.git', :tag => '1.0' }
+  s.source   = { :git => 'https://github.com/kentnguyen/KNMultiItemSelector.git', :tag => '1.0.1' }
 
   s.source_files = 'KNMultiItemSelector/KNMultiItemSelector.{h,m}', 'KNMultiItemSelector/KNSelectorItem.{h,m}'
   s.resources = "KNMultiItemSelector/Images/*.png"


### PR DESCRIPTION
Hello. I found that when using cocoapods it would download a very old version of the code (commit tagged with version 1.0), and some basic stuff was not working well (preSelected options would not load properly, for instance, when one would initialise a KNMultiItemSelector via  'initWithItems:preselectedItems:title:placeholderText:delegate:' method.

Next step:
The only thing that would be missing 8once the pull request is accepted and merged) would be to publish to the official Spec repo the specs File.
For the time being, the latests changes can be accessed (using CocoaPods) by specifying in PodFile:

``` ruby
pod 'KNMultiItemSelector', :git => 'https://github.com/kentnguyen/KNMultiItemSelector.git'
```

once the changes are merged and the spec is publish into the cocoapods repo, the the normal way of:

``` ruby
pod 'KNMultiItemSelector', ~>'1.0.1'
```

will suffice.
